### PR TITLE
Fixing the generated Canonical Link

### DIFF
--- a/Kentico.AcceleratedMobilePages/AmpFilter.cs
+++ b/Kentico.AcceleratedMobilePages/AmpFilter.cs
@@ -361,6 +361,9 @@ namespace Kentico.AcceleratedMobilePages
             }
         }
 
+        /// <summary>
+        /// Splits the Friendly URL Extension, and returns the first element
+        /// </summary>
         private string GetFriendlyExtension()
         {
             var extensions = Settings.CmsFriendlyUrlExtension;

--- a/Kentico.AcceleratedMobilePages/AmpFilter.cs
+++ b/Kentico.AcceleratedMobilePages/AmpFilter.cs
@@ -235,8 +235,8 @@ namespace Kentico.AcceleratedMobilePages
 
             // Create a link pointing to the regular HTML version of the page
             string canonicalLink = (CMSHttpContext.Current.Request.IsSecureConnection ? Constants.P_HTTPS : Constants.P_HTTP) +
-                                   SiteContext.CurrentSite.DomainName + (DocumentContext.CurrentPageInfo.DocumentUrlPath ?? DocumentContext.CurrentAliasPath) +
-                                   Settings.CmsFriendlyUrlExtension;
+                                   SiteContext.CurrentSite.DomainName + (!String.IsNullOrEmpty(DocumentContext.CurrentPageInfo.DocumentUrlPath) ? DocumentContext.CurrentPageInfo.DocumentUrlPath : DocumentContext.CurrentAliasPath) +
+                                   GetFriendlyExtension();
 
             // Extend the <head> tag with the compulsory markup and CSS styles
             headTag += Constants.NEW_LINE +
@@ -359,6 +359,21 @@ namespace Kentico.AcceleratedMobilePages
                     node.Attributes.Remove(attrName);
                 }
             }
+        }
+
+        private string GetFriendlyExtension()
+        {
+            var extensions = Settings.CmsFriendlyUrlExtension;
+            if(extensions.Length > 0)
+            {
+                var extensionlist = extensions.Split(';');
+                if (extensionlist.Length > 0)
+                {
+                    return extensionlist[0];
+                }
+            }
+            
+            return "";
         }
     }
 }

--- a/Kentico.AcceleratedMobilePages/AmpFilter.cs
+++ b/Kentico.AcceleratedMobilePages/AmpFilter.cs
@@ -69,8 +69,8 @@ namespace Kentico.AcceleratedMobilePages
         {
             string ampLink = (CMSHttpContext.Current.Request.IsSecureConnection ? Constants.P_HTTPS : Constants.P_HTTP) +
                              Settings.AmpFilterDomainAlias +
-                             (DocumentContext.CurrentPageInfo.DocumentUrlPath ?? DocumentContext.CurrentAliasPath) +
-                             Settings.CmsFriendlyUrlExtension;
+                             (!String.IsNullOrEmpty(DocumentContext.CurrentPageInfo.DocumentUrlPath) ? DocumentContext.CurrentPageInfo.DocumentUrlPath : DocumentContext.CurrentAliasPath) +
+                             GetFriendlyExtension();
             string metaTag = String.Format(Constants.AMP_AMP_HTML_LINK, ampLink) + Constants.NEW_LINE;
             // Insert meta tag
             finalHtml = Regex.Replace(finalHtml, "</head>", metaTag + "</head>");

--- a/Kentico.AcceleratedMobilePages/AmpFilter.cs
+++ b/Kentico.AcceleratedMobilePages/AmpFilter.cs
@@ -375,8 +375,7 @@ namespace Kentico.AcceleratedMobilePages
                     return extensionlist[0];
                 }
             }
-            
-            return "";
+            return extensions;
         }
     }
 }

--- a/Kentico.AcceleratedMobilePages/Constants.cs
+++ b/Kentico.AcceleratedMobilePages/Constants.cs
@@ -56,7 +56,7 @@
             "//meta[translate(@name,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"viewport\"]",
             "//script[not(translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"application/ld+json\") and not(@async and @custom-element)]",
             "//input[translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"image\" or translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"button\" or translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"password\" or translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"file\"]",
-            "//link[translate(@rel,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"preconnect\" or translate(@rel,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"prerender\" or translate(@rel,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"prefetch\"]",
+            "//link[translate(@rel,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"preconnect\" or translate(@rel,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"prerender\" or translate(@rel,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"prefetch\"  or (translate(@rel,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"preload\" and translate(@as,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"style\") ]",
             "//meta[@http-equiv]",
             "//a[starts-with(@href,\"javascript:\")][not(contains(@target,\"_blank\"))]",
             "//style",

--- a/README.md
+++ b/README.md
@@ -136,3 +136,5 @@ Tested with Kentico 11.0 (net46).
 ## [Questions & Support](https://github.com/Kentico/Home/blob/master/README.md)
 
 ## [License](https://github.com/Kentico/kentico-amp/blob/master/LICENSE.txt)
+
+


### PR DESCRIPTION
In Kentico 11, I was experiencing an issue where the canonical urls (both rel="amphtml" and rel="canonical" only contained the root domain, and was incorrectly appending all the url friendly extensions to the URL.

I adjusted the code to return the CurrentAliasPath when DocumentContext.CurrentPageInfo.DocumentUrlPath is null or empty, instead of just null.