### PR TITLE
Review changes for PR31: Fixing the generated Canonical Link

### DIFF
--- a/CMS/CMSModules/Kentico.AcceleratedMobilePages/Default.aspx.cs
+++ b/CMS/CMSModules/Kentico.AcceleratedMobilePages/Default.aspx.cs
@@ -57,7 +57,7 @@ public partial class CMSModules_AcceleratedMobilePages_Default : CMSPropertiesPa
             CurrentMaster.HeaderActions.Enabled = false;
         }
 
-        if (Node != null && !URLHelper.IsPostback())
+        if (Node != null && !RequestHelper.IsPostBack())
         {
             ReloadData();
         }

--- a/Kentico.AcceleratedMobilePages/AmpFilter.cs
+++ b/Kentico.AcceleratedMobilePages/AmpFilter.cs
@@ -20,6 +20,12 @@ namespace Kentico.AcceleratedMobilePages
 
 
         /// <summary>
+        /// Returns URL protocol prefix depending on the current connection
+        /// </summary>
+        private string ConnectionProtocolPrefix => CMSHttpContext.Current.Request.IsSecureConnection ? Constants.P_HTTPS : Constants.P_HTTP;
+
+
+        /// <summary>
         /// If the filter is enabled for current page, final HTML will be modified
         /// </summary>
         /// <param name="filter">Output filter</param>
@@ -67,10 +73,9 @@ namespace Kentico.AcceleratedMobilePages
         /// <param name="finalHtml">Final HTML string</param>
         private string AppendAmpHtmlLink(string finalHtml)
         {
-            string ampLink = (CMSHttpContext.Current.Request.IsSecureConnection ? Constants.P_HTTPS : Constants.P_HTTP) +
+            string ampLink = ConnectionProtocolPrefix +
                              Settings.AmpFilterDomainAlias +
-                             (!String.IsNullOrEmpty(DocumentContext.CurrentPageInfo.DocumentUrlPath) ? DocumentContext.CurrentPageInfo.DocumentUrlPath : DocumentContext.CurrentAliasPath) +
-                             GetFriendlyExtension();
+                             GetDocumentPath();
             string metaTag = String.Format(Constants.AMP_AMP_HTML_LINK, ampLink) + Constants.NEW_LINE;
             // Insert meta tag
             finalHtml = Regex.Replace(finalHtml, "</head>", metaTag + "</head>");
@@ -234,9 +239,9 @@ namespace Kentico.AcceleratedMobilePages
             string styles = GetStylesheetText();
 
             // Create a link pointing to the regular HTML version of the page
-            string canonicalLink = (CMSHttpContext.Current.Request.IsSecureConnection ? Constants.P_HTTPS : Constants.P_HTTP) +
-                                   SiteContext.CurrentSite.DomainName + (!String.IsNullOrEmpty(DocumentContext.CurrentPageInfo.DocumentUrlPath) ? DocumentContext.CurrentPageInfo.DocumentUrlPath : DocumentContext.CurrentAliasPath) +
-                                   GetFriendlyExtension();
+            string canonicalLink = ConnectionProtocolPrefix +
+                                   SiteContext.CurrentSite.DomainName +
+                                   GetDocumentPath();
 
             // Extend the <head> tag with the compulsory markup and CSS styles
             headTag += Constants.NEW_LINE +
@@ -361,21 +366,17 @@ namespace Kentico.AcceleratedMobilePages
             }
         }
 
+        
         /// <summary>
-        /// Splits the Friendly URL Extension, and returns the first element
+        /// Returns path of the currently processed document
         /// </summary>
-        private string GetFriendlyExtension()
+        private string GetDocumentPath()
         {
-            var extensions = Settings.CmsFriendlyUrlExtension;
-            if(extensions.Length > 0)
-            {
-                var extensionlist = extensions.Split(';');
-                if (extensionlist.Length > 0)
-                {
-                    return extensionlist[0];
-                }
-            }
-            return extensions;
+            var documentPath = !String.IsNullOrEmpty(DocumentContext.CurrentPageInfo.DocumentUrlPath)
+                                ? DocumentContext.CurrentPageInfo.DocumentUrlPath
+                                : DocumentContext.CurrentAliasPath;
+
+            return documentPath + Settings.CmsFriendlyUrlExtension;
         }
     }
 }

--- a/Kentico.AcceleratedMobilePages/AmpFilter.cs
+++ b/Kentico.AcceleratedMobilePages/AmpFilter.cs
@@ -361,6 +361,9 @@ namespace Kentico.AcceleratedMobilePages
             }
         }
 
+        /// <summary>
+        /// Splits the Friendly URL Extension, and returns the first element
+        /// </summary>
         private string GetFriendlyExtension()
         {
             var extensions = Settings.CmsFriendlyUrlExtension;

--- a/Kentico.AcceleratedMobilePages/AmpFilter.cs
+++ b/Kentico.AcceleratedMobilePages/AmpFilter.cs
@@ -235,8 +235,8 @@ namespace Kentico.AcceleratedMobilePages
 
             // Create a link pointing to the regular HTML version of the page
             string canonicalLink = (CMSHttpContext.Current.Request.IsSecureConnection ? Constants.P_HTTPS : Constants.P_HTTP) +
-                                   SiteContext.CurrentSite.DomainName + (DocumentContext.CurrentPageInfo.DocumentUrlPath ?? DocumentContext.CurrentAliasPath) +
-                                   Settings.CmsFriendlyUrlExtension;
+                                   SiteContext.CurrentSite.DomainName + (!String.IsNullOrEmpty(DocumentContext.CurrentPageInfo.DocumentUrlPath) ? DocumentContext.CurrentPageInfo.DocumentUrlPath : DocumentContext.CurrentAliasPath) +
+                                   GetFriendlyExtension();
 
             // Extend the <head> tag with the compulsory markup and CSS styles
             headTag += Constants.NEW_LINE +
@@ -359,6 +359,21 @@ namespace Kentico.AcceleratedMobilePages
                     node.Attributes.Remove(attrName);
                 }
             }
+        }
+
+        private string GetFriendlyExtension()
+        {
+            var extensions = Settings.CmsFriendlyUrlExtension;
+            if(extensions.Length > 0)
+            {
+                var extensionlist = extensions.Split(';');
+                if (extensionlist.Length > 0)
+                {
+                    return extensionlist[0];
+                }
+            }
+            
+            return "";
         }
     }
 }

--- a/Kentico.AcceleratedMobilePages/AmpFilter.cs
+++ b/Kentico.AcceleratedMobilePages/AmpFilter.cs
@@ -69,8 +69,8 @@ namespace Kentico.AcceleratedMobilePages
         {
             string ampLink = (CMSHttpContext.Current.Request.IsSecureConnection ? Constants.P_HTTPS : Constants.P_HTTP) +
                              Settings.AmpFilterDomainAlias +
-                             (DocumentContext.CurrentPageInfo.DocumentUrlPath ?? DocumentContext.CurrentAliasPath) +
-                             Settings.CmsFriendlyUrlExtension;
+                             (!String.IsNullOrEmpty(DocumentContext.CurrentPageInfo.DocumentUrlPath) ? DocumentContext.CurrentPageInfo.DocumentUrlPath : DocumentContext.CurrentAliasPath) +
+                             GetFriendlyExtension();
             string metaTag = String.Format(Constants.AMP_AMP_HTML_LINK, ampLink) + Constants.NEW_LINE;
             // Insert meta tag
             finalHtml = Regex.Replace(finalHtml, "</head>", metaTag + "</head>");

--- a/Kentico.AcceleratedMobilePages/AmpFilter.cs
+++ b/Kentico.AcceleratedMobilePages/AmpFilter.cs
@@ -375,8 +375,7 @@ namespace Kentico.AcceleratedMobilePages
                     return extensionlist[0];
                 }
             }
-            
-            return "";
+            return extensions;
         }
     }
 }

--- a/Kentico.AcceleratedMobilePages/Constants.cs
+++ b/Kentico.AcceleratedMobilePages/Constants.cs
@@ -56,7 +56,7 @@
             "//meta[translate(@name,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"viewport\"]",
             "//script[not(translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"application/ld+json\") and not(@async and @custom-element)]",
             "//input[translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"image\" or translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"button\" or translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"password\" or translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"file\"]",
-            "//link[translate(@rel,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"preconnect\" or translate(@rel,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"prerender\" or translate(@rel,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"prefetch\"]",
+            "//link[translate(@rel,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"preconnect\" or translate(@rel,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"prerender\" or translate(@rel,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"prefetch\"  or (translate(@rel,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"preload\" and translate(@as,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=\"style\") ]",
             "//meta[@http-equiv]",
             "//a[starts-with(@href,\"javascript:\")][not(contains(@target,\"_blank\"))]",
             "//style",

--- a/Kentico.AcceleratedMobilePages/Settings.cs
+++ b/Kentico.AcceleratedMobilePages/Settings.cs
@@ -9,7 +9,7 @@ namespace Kentico.AcceleratedMobilePages
         /// <summary>
         /// Gets extensions that the system adds to page URLs on current site.
         /// </summary>
-        public static string CmsFriendlyUrlExtension => SettingsKeyInfoProvider.GetValue(SiteContext.CurrentSiteName + ".CMSFriendlyURLExtension");
+        public static string CmsFriendlyUrlExtension => SettingsKeyInfoProvider.GetValue(SiteContext.CurrentSiteName + ".CMSFriendlyURLExtension").Split(';')[0];
 
 
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -136,3 +136,5 @@ Tested with Kentico 11.0 (net46).
 ## [Questions & Support](https://github.com/Kentico/Home/blob/master/README.md)
 
 ## [License](https://github.com/Kentico/kentico-amp/blob/master/LICENSE.txt)
+
+

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Accelerated Mobile Pages Module (AMP Filter) is a custom module for Kentico CMS and EMS. It consists of an [Output Filter](https://docs.kentico.com/k11/configuring-kentico/using-output-filters) for transforming regular HTML to AMP HTML format and a macro method that makes it easy to adjust and fine-tune the rendered output. The project is based on a [master thesis (EN)](https://is.muni.cz/th/409956/fi_m/?lang=en) of Daniel Minarik ([full text](https://is.muni.cz/th/409956/fi_m/thesis.pdf)).
 
-:bulb: Read [how we implemented AMP](https://devnet.kentico.com/articles/google-amping-the-kentico-advantage-site) on [Kentico Advantage website](http://amp.advantage.kentico.com/).
+:bulb: Read [how we implemented AMP](https://devnet.kentico.com/articles/google-amping-the-kentico-advantage-site) on Kentico Advantage website.
 
 ## Usage
 
@@ -39,7 +39,7 @@ There are several ways of including cascading style sheets into an AMP page:
 *	If none of the previous options is set, the AMP Filter will use the regular CSS stylesheet assigned to the page (either the site's default stylesheet or the page-specifc one). This option is not recommended, as the stylesheet could be bigger than 50kB (e.g., if it contains styles for the whole website).
 
 ### Further customization of AMP pages
-The AMP standard offers a lot of components or tags which do not have an ordinary HTML equivalent, and therefore, they can't be automatically injected or replaced in the page's source code. 
+The AMP standard offers a lot of components or tags which do not have an ordinary HTML equivalent, and therefore, they can't be automatically injected or replaced in the page's source code.
 
 You can use the `{% AmpFilter.IsAmpPage() %}` macro to find out whether the AMP Filter is enabled and active on the current page. This is useful for showing and hiding different parts of a web page. To do that, use the macro as a visibility condition of a web part.
 
@@ -66,7 +66,7 @@ Some advanced replacements (which were not possible to implement using the HtmlA
 
 ### Cascading style sheets
 The AMP Filter does not transform cascading stylesheets in any way. The developer must ensure that the stylesheet complies with [AMP HTML specification - stylesheet restrictions](https://www.ampproject.org/docs/reference/spec#stylesheets).
- 
+
 
 ### Global settings
 AMP Filter has two types of global settings:
@@ -91,7 +91,7 @@ Even when using the AMP Filter there are still some things that need to be handl
 * For simple sites with CSS totalling no more than 50kB in size (and adhering to the official [AMP rules](https://www.ampproject.org/docs/reference/spec#stylesheets)), there's no need to create AMP-specific stylesheets - the sites will work correctly with the regular stylesheets.
 
 * The AMP filter is mainly intened for simple, static pages, i.e. pages containing regular HTML. Only the `<img>`, `<video>`, `<audio>`, and `<iframe>` interactive elements (adhering to the [AMP HTML Specification](https://www.ampproject.org/docs/fundamentals/spec)) are allowed. Pages that fulfill these requirements will be transformed into the AMP format.
- 
+
 * The static `<form>` element used by ASP.NET web forms to store metadata and viewstate information is also converted to the AMP format. However, standard `<form>` elements included in the page's markup will not be submitted and processed by the server at all. To implement standard on-line form functionality (via the `<form>` tag), refer to the [amp-form](https://www.ampproject.org/docs/reference/components/amp-form) section of the official AMP documentation.
 
 ## Developing the module and contributing
@@ -103,33 +103,36 @@ Even when using the AMP Filter there are still some things that need to be handl
  1. Navigate to the root of the project (where the .sln file is)
  1. Fork this repo
  1. Init a git repo and fetch the web part
-        
+
         git init
         git remote add origin https://github.com/OWNER/kentico-amp.git
         git fetch
         git checkout origin/master -ft
 
  1. Restore DB data
-        
+
         Kentico\CMS\bin\ContinuousIntegration.exe -r
 
- 1. Open the web project in Visual Studio
- 1. Add `Kentico.AcceleratedMobilePages\Kentico.AcceleratedMobilePages.csproj` to the solution
- 1. Add `Kentico.AcceleratedMobilePages.Publisher\Kentico.AcceleratedMobilePages.Publisher.csproj` to the solution
- 1. Add reference from CMSApp to Kentico.AcceleratedMobilePages.csproj
- 1. Add reference from CMSApp to Kentico.AcceleratedMobilePages.Publisher.csproj
- 1. Build the solution
+ 1. Open the solution in Visual Studio
+ 1. Add the following projects to the solution:
+    * `Kentico.AcceleratedMobilePages\Kentico.AcceleratedMobilePages.csproj`
+    * `Kentico.AcceleratedMobilePages.Publisher\Kentico.AcceleratedMobilePages.Publisher.csproj`
+ 1. Reference the added projects from the CMSApp project:
+    1. Right-click the CMSApp project and select Add -> Reference...
+    1. Click Browse... and locate the projects on your filesystem
+    1. Click Add
+ 1. Rebuild the solution
  1. [Resign all macros](https://docs.kentico.com/k11/macro-expressions/troubleshooting-macros/working-with-macro-signatures)
  1. Optional: Assign the module to one or more sites
  1. Make changes
  1. Use combination of `git add`, `git commit` and `git push` to transfer your changes to GitHub
-        
+
         git status
         git commit -a -m "Fix XY"
         git push
-        
+
  1. Submit a pull request
-  
+
 ## Compatibility
 Tested with Kentico 11.0 (net46).
 


### PR DESCRIPTION
As @kile-lindgren wrote in [PR31: Fixing the generated Canonical Link](https://github.com/Kentico/kentico-amp/pull/31):

> In Kentico 11, I was experiencing an issue where the canonical urls (both rel="amphtml" and rel="canonical" only contained the root domain, and was incorrectly appending all the url friendly extensions to the URL.
I adjusted the code to return the CurrentAliasPath when DocumentContext.CurrentPageInfo.DocumentUrlPath is null or empty, instead of just null.

Changes in this PR are review changes, where the previous discussion left off.
Also, update of Readme.md is included, which contains removing invalid link and clarifying the steps in 'How to develop'.